### PR TITLE
Fixed the User-Agreement & Instructions Bugs in Safari

### DIFF
--- a/app/stores/useragreementstore.js
+++ b/app/stores/useragreementstore.js
@@ -12,22 +12,22 @@ var userAgreementStore = Reflux.createStore({
 	listenables: [userAgreementActions],
 
 	onShowText() {
-	  
+
         /*
         var a = document.createElement('a');
         a.href = "http://apple.com";
         document.body.appendChild(a);
-        a.click(); 
+        a.click();
         */
-     
+
         //used to check if there is already a user agreement window generated before, clears it so we don't re-generate it
         if(document.getElementById("userAgreement")){
             document.body.removeChild(userAgreement);
 
         }
-        
-  
-        
+
+
+
         var a = document.createElement('a');
         a.href = "#userAgreement";
 
@@ -37,7 +37,7 @@ var userAgreementStore = Reflux.createStore({
         userAgreementElement.className = "modalDialog";
         document.body.appendChild(a);
         document.body.appendChild(userAgreementElement);
-        
+
         a.click(); //to trigger next part, aka generating the modal window and darkened bg
         //document.body.removeChild(a);
 
@@ -62,12 +62,13 @@ var userAgreementStore = Reflux.createStore({
         //img.src = '<img src="img/ubc_logo_alpha_gone.png" />';
         img.src = require("../../img/ubc_logo_alpha_gone.png");
         //img.src = require("/Users/Matthew/Macaron/img/test.gif");
-        img.style = "width:40px;height:51px;";
+        img.style.width = "40px";
+				img.style.height = "51px";
         //img.style = "width:320px;height:240px";
         img.alt = "Example Image Location";
         //document.getElementById("inner").appendChild(img);
- 
-        //The actual placeholder title location 
+
+        //The actual placeholder title location
         var userAgreementHeaderElement = document.createElement("userAgreementHeaderElement");
         //var imgPlaceHolder = document.createElement("img");
         //imgPlaceHolder.id = "imgPlaceHolder";
@@ -76,14 +77,14 @@ var userAgreementStore = Reflux.createStore({
         //userAgreementHeaderElement.innerHTML = img;
         userAgreementHeaderElement.innerHTML = "<h2 class='userAgreementHeader'> <img src='" + img.src + "' alt='Example Image' style='width:40px;height:50px;'>Privacy policy statement </h2>";
         document.getElementById("inner").appendChild(userAgreementHeaderElement);
-    
-        
+
+
         //The actual placeholder text location
         var userAgreementTextElement = document.createElement("userAgreementTextElement");
         userAgreementTextElement.id = "macaronText";
         userAgreementTextElement.innerHTML = "<p>Macaron is research software developed by the SPIN research group at the University of British Columbia (UBC). As part of our commitment to improving our tools and conducting user interface research, we collect <b>anonymous</b> information about your interactions with Macaron, similar to other online tools. This includes data like: </p>";
         document.getElementById("inner").appendChild(userAgreementTextElement);
-        
+
         //The actual placeholder text listed items, note the list item omits quotes for telemetry... okay?
         var userAgreementListElement = document.createElement("userAgreementListElement");
         userAgreementListElement.innerHTML = "<ul><li>Usage statistics (or telemetry). This includes time spent using the tool or interacting with various elements, and interaction patterns (eg. clicks, mouse movements, key presses, commands)</li><li>Software environment to understand performance, compatibility, and demographics (eg. browser or operating system version).</li><li>Your IP address is used for recording general location (i.e., region: state or country), but not stored directly and never linked to any personal information.</li><li>Information you supply to us directly, for example, through questionnaires, feedback forms, or crash reports.</li></ul>";
@@ -93,17 +94,17 @@ var userAgreementStore = Reflux.createStore({
         var userAgreementTextElementCont = document.createElement("userAgreementTextElementCont");
         userAgreementTextElementCont.innerHTML = "<p>The data we collect will be used to help us further develop Macaron and similar tools. This data may be published as part of our academic research, eg., at conferences, talks, or as video, articles, or online posts.</p>";
         document.getElementById("inner").appendChild(userAgreementTextElementCont);
-    
+
         var userAgreementTextElementFinalSeg = document.createElement("userAgreementTextElementFinalSeg");
         userAgreementTextElementFinalSeg.innerHTML = "<p><b>We do not collect, store, or report personal or identifiable information about you or your account.</b> The research project associated with this tool has been approved by UBC's Behavioural Ethics Research Board (#H13-01620). If you have any questions, please contact us at tmp@ubc.com.</p>";
         document.getElementById("inner").appendChild(userAgreementTextElementFinalSeg);
-    
+
         //This can work to prevent further appendments... but prevents link from opening in first place?
         //document.body.removeChild(userAgreementElement);
 
 
-      
-  
+
+
 	}
 });
 

--- a/app/stores/userinstructionsstore.js
+++ b/app/stores/userinstructionsstore.js
@@ -18,7 +18,7 @@ var userInstructionsStore = Reflux.createStore({
             document.body.removeChild(page1);
 
         }
-    
+
     	var a = document.createElement('a');
         a.href = "#page1";
 
@@ -28,15 +28,15 @@ var userInstructionsStore = Reflux.createStore({
         userInstructionsElement.className = "modalDialogInstructions";
         document.body.appendChild(a);
         document.body.appendChild(userInstructionsElement);
-        
+
         a.click();
 
         //the main div that all the main text elements will go under
         var inner1 = document.createElement("div");
         inner1.id = "inner1";
         document.getElementById("page1").appendChild(inner1);
-        
-        //should be able to re-use 
+
+        //should be able to re-use
         a.href = "#close";
         a.title = "Close";
         a.className = "close";
@@ -51,7 +51,7 @@ var userInstructionsStore = Reflux.createStore({
 
         //need a div to centre image and text
         var centre = document.createElement("div");
-        centre.style = "text-align:center;";
+        centre.style.textAlign = "center";
         centre.id = "centre";
         document.getElementById("inner1").appendChild(centre);
 
@@ -66,13 +66,13 @@ var userInstructionsStore = Reflux.createStore({
         userInstructionsImageLocation.id = "macaronText";
         userInstructionsImageLocation.innerHTML = "<p><img src='" + img.src + "' alt='Example Image'></p>";
         document.getElementById("centre").appendChild(userInstructionsImageLocation);
-  
+
         //The actual instruction text location
         var userInstructionsTextElement = document.createElement("userAgreementTextElement");
         userInstructionsTextElement.id = "macaronInstruction";
         userInstructionsTextElement.innerHTML = "<p>Thank you for using Macaron! Below are quick references to the most important interface elements. Please make sure to plug in an actuator to the headphone jack of your computer to feel the vibrations. <b>Please remember to unmute the button when editing or playing back any vibrations.</b></p>";
         document.getElementById("inner1").appendChild(userInstructionsTextElement);
-   
+
         //The actual instruction text location continued eg. bullet point list
         var userInstructionsListElement = document.createElement("userInstructionsListElement");
         userInstructionsListElement.innerHTML = "<ul><li><b>A: </b>The left hand pane here is the area where you can edit your current vibration in terms of amplitude and frequency</li><li><b>B: </b>The top pane is where you can view the vibration in their overall waveform distribution</li><li><b>C: </b>The left axes here shows that you can specifically target a vibration pattern's amplitude or frequency to be edited</li><li><b>D: </b>The right hand pane here is the area where you can load an example vibration pattern that can be viewed (not edited)</li><li><b>E: </b>The Mute button is on by default when loading Macaron in order to prevent constant vibrations of any actuators plugged in</li><li><b>F: </b>The top header here contains the User Agreement, and Save/Load buttons for backing up your current vibrations being edited</li></ul>";
@@ -85,7 +85,7 @@ var userInstructionsStore = Reflux.createStore({
         a.className = "nextPageButton";
         a.innerHTML = "Next";
         document.getElementById("inner1").appendChild(a);
-        //a.click(); 
+        //a.click();
 
         /*****************************************************************************************************
         ******************************************************************************************************
@@ -106,7 +106,7 @@ var userInstructionsStore = Reflux.createStore({
 
         var a = document.createElement('a');
         a.href = "#page2";
-   
+
         var userInstructionsElement = document.createElement("div");
         userInstructionsElement.id = "page2";
         userInstructionsElement.className = "modalDialogInstructions";
@@ -119,8 +119,8 @@ var userInstructionsStore = Reflux.createStore({
         var inner2 = document.createElement("div");
         inner2.id = "inner2";
         document.getElementById("page2").appendChild(inner2);
-        
-        //should be able to re-use 
+
+        //should be able to re-use
         a.href = "#close";
         a.title = "Close";
         a.className = "close";
@@ -135,7 +135,7 @@ var userInstructionsStore = Reflux.createStore({
 
         //div to centre
         var centre2 = document.createElement("div");
-        centre2.style = "text-align:center;";
+        centre2.style.textAlign = "center";
         centre2.id = "centre2";
         document.getElementById("inner2").appendChild(centre2);
 
@@ -156,7 +156,7 @@ var userInstructionsStore = Reflux.createStore({
         userInstructionsTextElement2.id = "macaronInstruction2";
         userInstructionsTextElement2.innerHTML = "<p>You can playback any vibrations through the respective 'play' icon for either your currently selected example vibration (right side), or your own custom vibration (left side).<br></br>You can also skip to the beginning or the end of the vibration by using the left or right arrow icons. Manual scrubbing of the vibration is also possible by clicking and dragging the red position marker.</p>";
         document.getElementById("inner2").appendChild(userInstructionsTextElement2);
-     
+
         //the prev or next button location
         //prev
         var a = document.createElement('a');
@@ -172,7 +172,7 @@ var userInstructionsStore = Reflux.createStore({
         a.className = "nextPageButton";
         a.innerHTML = "Next";
         document.getElementById("inner2").appendChild(a);
-     
+
         /*****************************************************************************************************
         ******************************************************************************************************
         ******************************************************************************************************
@@ -182,7 +182,7 @@ var userInstructionsStore = Reflux.createStore({
         ******************************************************************************************************
         ******************************************************************************************************
         ******************************************************************************************************/
-    
+
         if(document.getElementById("page3")){
             document.body.removeChild(page3);
 
@@ -190,7 +190,7 @@ var userInstructionsStore = Reflux.createStore({
 
         var a = document.createElement('a');
         a.href = "#page3";
-   
+
         var userInstructionsElement = document.createElement("div");
         userInstructionsElement.id = "page3";
         userInstructionsElement.className = "modalDialogInstructions";
@@ -203,8 +203,8 @@ var userInstructionsStore = Reflux.createStore({
         var inner3 = document.createElement("div");
         inner3.id = "inner3";
         document.getElementById("page3").appendChild(inner3);
-        
-        //should be able to re-use 
+
+        //should be able to re-use
         a.href = "#close";
         a.title = "Close";
         a.className = "close";
@@ -219,7 +219,7 @@ var userInstructionsStore = Reflux.createStore({
 
         //div to centre
         var centre3 = document.createElement("div");
-        centre3.style = "text-align:center;";
+        centre3.style.textAlign = "center";
         centre3.id = "centre3";
         document.getElementById("inner3").appendChild(centre3);
 
@@ -274,7 +274,7 @@ var userInstructionsStore = Reflux.createStore({
 
         var a = document.createElement('a');
         a.href = "#page4";
-   
+
         var userInstructionsElement = document.createElement("div");
         userInstructionsElement.id = "page4";
         userInstructionsElement.className = "modalDialogInstructions";
@@ -287,8 +287,8 @@ var userInstructionsStore = Reflux.createStore({
         var inner4 = document.createElement("div");
         inner4.id = "inner4";
         document.getElementById("page4").appendChild(inner4);
-        
-        //should be able to re-use 
+
+        //should be able to re-use
         a.href = "#close";
         a.title = "Close";
         a.className = "close";
@@ -303,7 +303,7 @@ var userInstructionsStore = Reflux.createStore({
 
         //div to centre
         var centre4 = document.createElement("div");
-        centre4.style = "text-align:center;";
+        centre4.style.textAlign = "center";
         centre4.id = "centre4";
         document.getElementById("inner4").appendChild(centre4);
 
@@ -324,7 +324,7 @@ var userInstructionsStore = Reflux.createStore({
         userInstructionsTextElement4.id = "macaronInstruction4";
         userInstructionsTextElement4.innerHTML = "<p>You can make your own vibration pattern by clicking on the shaded area on the left hand side to create points that can be dragged around to invoke changes in amplitude or frequncy.</p>";
         document.getElementById("inner4").appendChild(userInstructionsTextElement4);
-     
+
         //the prev or next button location
         //prev
         var a = document.createElement('a');
@@ -358,7 +358,7 @@ var userInstructionsStore = Reflux.createStore({
 
         var a = document.createElement('a');
         a.href = "#page5";
-   
+
         var userInstructionsElement = document.createElement("div");
         userInstructionsElement.id = "page5";
         userInstructionsElement.className = "modalDialogInstructions";
@@ -371,8 +371,8 @@ var userInstructionsStore = Reflux.createStore({
         var inner5 = document.createElement("div");
         inner5.id = "inner5";
         document.getElementById("page5").appendChild(inner5);
-        
-        //should be able to re-use 
+
+        //should be able to re-use
         a.href = "#close";
         a.title = "Close";
         a.className = "close";
@@ -387,7 +387,7 @@ var userInstructionsStore = Reflux.createStore({
 
         //div to centre
         var centre5 = document.createElement("div");
-        centre5.style = "text-align:center;";
+        centre5.style.textAlign = "center";
         centre5.id = "centre5";
         document.getElementById("inner5").appendChild(centre5);
 
@@ -408,7 +408,7 @@ var userInstructionsStore = Reflux.createStore({
         userInstructionsTextElement5.id = "macaronInstruction5";
         userInstructionsTextElement5.innerHTML = "<p>You can save your own vibration pattern by clicking the Save button in the top right corner. This will save a file that contains your current progress locally onto your computer. If you ever need to go back to a past pattern, just click the Load button to load this file which will revert your pattern.</p>";
         document.getElementById("inner5").appendChild(userInstructionsTextElement5);
-     
+
         //the prev or next button location
         //prev
         var a = document.createElement('a');
@@ -417,7 +417,7 @@ var userInstructionsStore = Reflux.createStore({
         a.className = "prevPageButton";
         a.innerHTML = "Prev";
         document.getElementById("inner5").appendChild(a);
-        
+
 	}
 });
 


### PR DESCRIPTION
I managed to get the User Agreement and Instructions pop-ups to appear in Safari by changing the way some stylings were modified in Javascript. e.g.
```el.style = "text-align:center;";``` to ```el.style.textAlign = "center";```